### PR TITLE
Make key shortcut match description.

### DIFF
--- a/keymaps/mei-tools-atom.json
+++ b/keymaps/mei-tools-atom.json
@@ -1,5 +1,5 @@
 {
   "atom-workspace": {
-    "ctrl-alt-cmd-m": "mei-tools-atom:toggle"
+    "ctrl-alt-m": "mei-tools-atom:toggle"
   }
 }

--- a/lib/mei-tools-atom.js
+++ b/lib/mei-tools-atom.js
@@ -95,16 +95,16 @@ export default {
     }
 
     if(ext === ".musicxml" || ext === ".xml"){
-      this.vrvToolkit.loadData(this.activeEditor.getText());
+      // Erase all existing xml:ids.
+      let temp = this.activeEditor.getText().replace(/ xml:id=['"]\S+['"]/g, "");
+      // Generate new enumerated xml:ids.
+      temp = temp.replace(/(?:<)([a-zA-Z]+)/g, genId);
+
+      this.vrvToolkit.loadData(temp);
       const log = this.vrvToolkit.getLog();
 
       if(log === ''){ // success
         let newPath = this.resolveNewFileName(path.dirname(fullPath), '.mei');
-        // Erase all existing xml:ids.
-        let temp = this.activeEditor.getText().replace(/ xml:id=['"]\S+['"]/g, ""); //TODO: fix text getting
-        // Generate new enumerated xml:ids.
-        temp = temp.replace(/(?:<)([a-zA-Z]+)/g, genId);
-        this.activeEditor.setText(temp); //TODO: fix text setting
 
         const mei = this.vrvToolkit.getMEI(1, 1); // page 1, scoreBased
 

--- a/lib/mei-tools-atom.js
+++ b/lib/mei-tools-atom.js
@@ -12,6 +12,7 @@ export default {
   subscriptions: null,
   activeEditor: null,
   vrvToolkit: new Verovio.toolkit(),
+  highest_xmlid: 0,
 
   activate(state) {
     require('atom-package-deps').install('mei-tools-atom')
@@ -53,6 +54,7 @@ export default {
     this.subscriptions.dispose();
     this.activeEditor = null;
     this.vrvToolkit = null;
+    this.highest_xmlid = null;
   },
 
   toggle() {
@@ -75,6 +77,11 @@ export default {
     return fullPath;
   },
 
+  genId(match, elType, offset, origStr) {
+    let temp = String(++highestXmlId);
+    return [match, " xml:id=\"", elType.toLowerCase(), "-", temp, "\""].join("");
+  },
+
   convertToMEI() {
     const fullPath = this.activeEditor.getPath()
     const ext = path.extname(fullPath);
@@ -93,6 +100,11 @@ export default {
 
       if(log === ''){ // success
         let newPath = this.resolveNewFileName(path.dirname(fullPath), '.mei');
+        // Erase all existing xml:ids.
+        let temp = this.activeEditor.getText().replace(/ xml:id=['"]\S+['"]/g, ""); //TODO: fix text getting
+        // Generate new enumerated xml:ids.
+        temp = temp.replace(/(?:<)([a-zA-Z]+)/g, genId);
+        this.activeEditor.setText(temp); //TODO: fix text setting
 
         const mei = this.vrvToolkit.getMEI(1, 1); // page 1, scoreBased
 


### PR DESCRIPTION
Changes keyboard shortcut to toggle notation view from CTRL+ALT+CMD+M to CTRL+ALT+M. The new shortcut works upon restarting Atom, but the shortcut is no longer displayed when you click on Packages>MEI Tools. I'm not sure why that is.